### PR TITLE
fix: cleanup wrong value of unused design tokens

### DIFF
--- a/proprietary/design-tokens/src/sync/common.tokens.json
+++ b/proprietary/design-tokens/src/sync/common.tokens.json
@@ -404,29 +404,6 @@
     }
   },
   "Nijmegen": {
-    "breakpoints": {
-      "xs": {
-        "value": "0-399px",
-        "type": "dimension",
-        "description": "\t•\trange: Voor schermen kleiner dan 400px.\n\t•\tmargins: Buitenmarges ingesteld op 16px.\n\t•\tgutters: Binnenruimtes ingesteld op 16px."
-      },
-      "sm": {
-        "value": "400px - 699px",
-        "type": "dimension"
-      },
-      "md": {
-        "value": "700px - 991px",
-        "type": "dimension"
-      },
-      "lg": {
-        "value": "992px - 1312px",
-        "type": "dimension"
-      },
-      "xl": {
-        "value": "> 1312px",
-        "type": "dimension"
-      }
-    },
     "margins": {
       "xs": {
         "value": "16px",


### PR DESCRIPTION
Dit fixt een bug waardoor ik de tokens niet (netjes) kan inladen in de component library dus ook graag een nieuwe release draaien na de merge.