### PR TITLE
style: remove and add common border tokens

### DIFF
--- a/proprietary/design-tokens/src/sync/brand.tokens.json
+++ b/proprietary/design-tokens/src/sync/brand.tokens.json
@@ -3,31 +3,35 @@
     "typography": {
       "font-size": {
         "xs": {
-          "value": "14px",
+          "value": "0.875rem",
           "type": "fontSizes"
         },
         "sm": {
-          "value": "16px",
+          "value": "1rem",
           "type": "fontSizes"
         },
         "md": {
-          "value": "18px",
+          "value": "1.125rem",
           "type": "fontSizes"
         },
         "lg": {
-          "value": "24px",
+          "value": "1.25rem",
           "type": "fontSizes"
         },
         "xl": {
-          "value": "32px",
+          "value": "1.5rem",
           "type": "fontSizes"
         },
         "2xl": {
-          "value": "40px",
+          "value": "2rem",
           "type": "fontSizes"
         },
         "3xl": {
-          "value": "48px",
+          "value": "2.5rem",
+          "type": "fontSizes"
+        },
+        "4xl": {
+          "value": "3rem",
           "type": "fontSizes"
         }
       },
@@ -50,22 +54,22 @@
         }
       },
       "font-weight": {
-        "normal": {
-          "value": "Regular",
+        "regular": {
+          "value": "400",
           "type": "fontWeights"
         },
         "bold": {
-          "value": "Bold",
+          "value": "700",
           "type": "fontWeights"
         },
-        "semi-bold": {
-          "value": "SemiBold",
+        "semibold": {
+          "value": "600",
           "type": "fontWeights"
         }
       },
       "font-family": {
         "primary": {
-          "value": "Oranda BT, Tahoma, Verdana, sans-serif",
+          "value": "Oranda BT, Georgia, serif",
           "type": "fontFamilies"
         },
         "secondary": {
@@ -75,609 +79,346 @@
       }
     },
     "color": {
-      "white": {
-        "value": "#ffffff",
+      "wit": {
+        "value": "#FFFFFF",
         "type": "color"
       },
       "zwart": {
         "value": "#000000",
         "type": "color"
       },
+      "none": {
+        "value": "#FFFFFF00",
+        "type": "color"
+      },
       "oranje": {
         "100": {
-          "value": "#FFD3A7",
+          "value": "#FEF1E5",
           "type": "color"
         },
         "200": {
-          "value": "#FFBE7B",
+          "value": "#FEE2C8",
           "type": "color"
         },
         "300": {
-          "value": "#FFA84E",
+          "value": "#FECA9D",
           "type": "color"
         },
         "400": {
-          "value": "#FF9222",
+          "value": "#FD8022",
           "type": "color"
         },
         "500": {
-          "value": "#F57C00",
+          "value": "#D96416",
+          "type": "color"
+        },
+        "600": {
+          "value": "#B25012",
+          "type": "color"
+        },
+        "700": {
+          "value": "#8F400D",
+          "type": "color"
+        },
+        "800": {
+          "value": "#6A2E09",
+          "type": "color"
+        },
+        "900": {
+          "value": "#431D07",
           "type": "color"
         }
       },
       "geel": {
         "100": {
-          "value": "#FFE9D3",
+          "value": "#FAF4D7",
           "type": "color"
         },
         "200": {
-          "value": "#ffef99",
+          "value": "#F4E8AA",
           "type": "color"
         },
         "300": {
-          "value": "#FFBE7B",
+          "value": "#EAD565",
           "type": "color"
         },
         "400": {
-          "value": "#ddb900",
+          "value": "#C0A100",
           "type": "color"
         },
         "500": {
-          "value": "#FFEB3B",
-          "type": "color"
-        }
-      },
-      "donkergeel": {
-        "100": {
-          "value": "#fff4db",
+          "value": "#9E8400",
           "type": "color"
         },
-        "200": {
-          "value": "#ffe9b8",
+        "600": {
+          "value": "#816C00",
           "type": "color"
         },
-        "300": {
-          "value": "#ffb612",
+        "700": {
+          "value": "#675600",
           "type": "color"
         },
-        "400": {
-          "value": "#bf880d",
+        "800": {
+          "value": "#4C3F00",
+          "type": "color"
+        },
+        "900": {
+          "value": "#2F2800",
           "type": "color"
         }
       },
       "blauw": {
         "100": {
-          "value": "#C7E3FF",
+          "value": "#ECF5FD",
           "type": "color"
         },
         "200": {
-          "value": "#7DD5FD",
+          "value": "#D7E9FB",
           "type": "color"
         },
         "300": {
-          "value": "#52C8FD",
+          "value": "#B8D8F8",
           "type": "color"
         },
         "400": {
-          "value": "#26BAFC",
-          "type": "color"
-        }
-      },
-      "donkerblauw": {
-        "100": {
-          "value": "#0074E5",
-          "type": "color"
-        },
-        "200": {
-          "value": "#028DCB",
-          "type": "color"
-        },
-        "300": {
-          "value": "#01557A",
-          "type": "color"
-        },
-        "400": {
-          "value": "#013851",
+          "value": "#5FA8EF",
           "type": "color"
         },
         "500": {
-          "value": "#002237",
+          "value": "#2588E9",
           "type": "color"
-        }
-      },
-      "light": {
-        "alpha": {
-          "50": {
-            "value": "#ffffff0d",
-            "type": "color"
-          },
-          "100": {
-            "value": "#ffffff1a",
-            "type": "color"
-          }
-        }
-      },
-      "dark": {
-        "alpha": {
-          "50": {
-            "value": "#0000000d",
-            "type": "color"
-          },
-          "100": {
-            "value": "#0000001a",
-            "type": "color"
-          }
+        },
+        "600": {
+          "value": "#006BD4",
+          "type": "color"
+        },
+        "700": {
+          "value": "#0056AA",
+          "type": "color"
+        },
+        "800": {
+          "value": "#003F7D",
+          "type": "color"
+        },
+        "900": {
+          "value": "#00284F",
+          "type": "color"
         }
       },
       "rood": {
         "100": {
-          "value": "#FBC0CD",
+          "value": "#FAF1F3",
           "type": "color"
         },
         "200": {
-          "value": "#F8829C",
+          "value": "#F5E2E6",
           "type": "color"
         },
         "300": {
-          "value": "#F4436A",
+          "value": "#EDCCD3",
           "type": "color"
         },
         "400": {
-          "value": "#E70E3E",
+          "value": "#D78F9F",
           "type": "color"
         },
         "500": {
+          "value": "#C9687E",
+          "type": "color"
+        },
+        "600": {
+          "value": "#BC415D",
+          "type": "color"
+        },
+        "700": {
           "value": "#A80A2D",
+          "type": "color"
+        },
+        "800": {
+          "value": "#830823",
+          "type": "color"
+        },
+        "900": {
+          "value": "#550517",
           "type": "color"
         }
       },
       "groen": {
-        "50": {
-          "value": "#ECFCF9",
-          "type": "color"
-        },
         "100": {
-          "value": "#C1F4EA",
+          "value": "#EDF6F0",
           "type": "color"
         },
         "200": {
-          "value": "#82EAD6",
+          "value": "#DAEBDF",
           "type": "color"
         },
         "300": {
-          "value": "#44DFC1",
+          "value": "#BDDCC6",
           "type": "color"
         },
         "400": {
-          "value": "#20BA9C",
+          "value": "#6EB281",
           "type": "color"
         },
         "500": {
-          "value": "#157C68",
+          "value": "#3C9756",
           "type": "color"
         },
         "600": {
-          "value": "#116353",
+          "value": "#1D7D38",
           "type": "color"
         },
         "700": {
-          "value": "#0D4A3E",
+          "value": "#17642D",
           "type": "color"
         },
         "800": {
-          "value": "#08322A",
+          "value": "#114A21",
           "type": "color"
         },
         "900": {
-          "value": "#041915",
+          "value": "#0B2E15",
           "type": "color"
         }
       },
       "grijs": {
         "100": {
-          "value": "#fbfbfb",
+          "value": "#F3F3F3",
           "type": "color"
         },
         "200": {
-          "value": "#f3f3f3",
+          "value": "#E7E7E7",
           "type": "color"
         },
         "300": {
-          "value": "#767676",
+          "value": "#D4D4D4",
           "type": "color"
         },
         "400": {
-          "value": "#545454",
+          "value": "#A3A3A3",
           "type": "color"
         },
         "500": {
-          "value": "#323232",
+          "value": "#868686",
           "type": "color"
         },
         "600": {
-          "value": "#292929",
+          "value": "#6D6D6D",
           "type": "color"
         },
         "700": {
-          "value": "#222222",
+          "value": "#575757",
           "type": "color"
         },
         "800": {
-          "value": "#1B1B1B",
+          "value": "#404040",
           "type": "color"
         },
         "900": {
-          "value": "#141414",
+          "value": "#282828",
           "type": "color"
         }
       },
-      "lichtgroen": {
-        "50": {
-          "value": "#D0F4DB",
-          "type": "color"
-        },
+      "zeegroen": {
         "100": {
-          "value": "#A2EAB6",
+          "value": "#EDF5F4",
           "type": "color"
         },
         "200": {
-          "value": "#73DF92",
+          "value": "#DAEAE7",
           "type": "color"
         },
         "300": {
-          "value": "#45D56E",
+          "value": "#BEDAD5",
           "type": "color"
         },
         "400": {
-          "value": "#2AB752",
+          "value": "#70AFA3",
           "type": "color"
         },
         "500": {
-          "value": "#1F883D",
+          "value": "#409484",
           "type": "color"
         },
         "600": {
-          "value": "#155B29",
+          "value": "#157C68",
           "type": "color"
         },
         "700": {
-          "value": "#10441F",
+          "value": "#116253",
           "type": "color"
         },
         "800": {
-          "value": "#0A2D14",
+          "value": "#0C483D",
           "type": "color"
         },
         "900": {
-          "value": "#05170A",
-          "type": "color"
-        }
-      },
-      "donkerrood": {
-        "100": {
-          "value": "#A41A1E",
-          "type": "color"
-        },
-        "200": {
-          "value": "#7B1317",
-          "type": "color"
-        },
-        "300": {
-          "value": "#520D0F",
-          "type": "color"
-        },
-        "400": {
-          "value": "#290608",
-          "type": "color"
-        }
-      },
-      "background-default": {
-        "value": "{nijmegen.color.white}",
-        "type": "color"
-      },
-      "background-subdued": {
-        "value": "{nijmegen.color.grijs.200}",
-        "type": "color"
-      },
-      "donkergroen": {
-        "100": {
-          "value": "#116757",
-          "type": "color"
-        },
-        "200": {
-          "value": "#0E5345",
-          "type": "color"
-        },
-        "300": {
-          "value": "#0A3E34",
-          "type": "color"
-        },
-        "400": {
-          "value": "#072923",
-          "type": "color"
-        },
-        "500": {
-          "value": "#031511",
+          "value": "#082D26",
           "type": "color"
         }
       }
     },
     "space": {
-      "inline": {
-        "3xs": {
-          "value": "2px",
-          "type": "spacing",
-          "description": "Extra small 3\t"
-        },
-        "2xs": {
-          "value": "4px",
-          "type": "spacing",
-          "description": "Extra small 2\t"
-        },
-        "xs": {
-          "value": "8px",
-          "type": "spacing",
-          "description": "Extra small\t"
-        },
-        "sm": {
-          "value": "12px",
-          "type": "spacing",
-          "description": "Extra small"
-        },
-        "md": {
-          "value": "16px",
-          "type": "spacing",
-          "description": "Medium"
-        },
-        "lg": {
-          "value": "20px",
-          "type": "spacing",
-          "description": "Large"
-        },
-        "xl": {
-          "value": "24px",
-          "type": "spacing",
-          "description": "Extra large"
-        },
-        "2xl": {
-          "value": "32px",
-          "type": "spacing"
-        },
-        "3xl": {
-          "value": "40px",
-          "type": "spacing"
-        },
-        "4xl": {
-          "value": "48px",
-          "type": "spacing"
-        },
-        "5xl": {
-          "value": "64px",
-          "type": "spacing"
-        }
+      "0": {
+        "value": "0rem",
+        "type": "spacing"
       },
-      "block": {
-        "3xs": {
-          "value": "2px",
-          "type": "spacing",
-          "description": "Extra small 3"
-        },
-        "2xs": {
-          "value": "4px",
-          "type": "spacing",
-          "description": "Extra small 2"
-        },
-        "xs": {
-          "value": "8px",
-          "type": "spacing",
-          "description": "Extra small"
-        },
-        "sm": {
-          "value": "12px",
-          "type": "spacing",
-          "description": "Small"
-        },
-        "md": {
-          "value": "16px",
-          "type": "spacing",
-          "description": "Medium"
-        },
-        "lg": {
-          "value": "20px",
-          "type": "spacing",
-          "description": "Large"
-        },
-        "xl": {
-          "value": "24px",
-          "type": "spacing",
-          "description": "Extra large"
-        },
-        "2xl": {
-          "value": "32px",
-          "type": "spacing",
-          "description": "Extra large 2"
-        },
-        "3xl": {
-          "value": "48px",
-          "type": "spacing",
-          "description": "Extra large 3"
-        },
-        "4xl": {
-          "value": "64px",
-          "type": "spacing"
-        },
-        "5xl": {
-          "value": "64px",
-          "type": "spacing"
-        }
+      "25": {
+        "value": "0.25rem",
+        "type": "spacing"
       },
-      "text": {
-        "4xs": {
-          "value": "1px",
-          "type": "spacing",
-          "description": "0.125ch"
-        },
-        "3xs": {
-          "value": "2px",
-          "type": "spacing",
-          "description": "0.25ch"
-        },
-        "2xs": {
-          "value": "4px",
-          "type": "spacing",
-          "description": "0.5ch"
-        },
-        "sm": {
-          "value": "6px",
-          "type": "spacing",
-          "description": "0.75ch"
-        },
-        "md": {
-          "value": "8px",
-          "type": "spacing",
-          "description": "1ch"
-        },
-        "lg": {
-          "value": "12px",
-          "type": "spacing",
-          "description": "1.5ch"
-        },
-        "xl": {
-          "value": "14px",
-          "type": "spacing",
-          "description": "1.75ch"
-        },
-        "2xl": {
-          "value": "16px",
-          "type": "spacing",
-          "description": "2ch"
-        },
-        "3xl": {
-          "value": "24px",
-          "type": "spacing",
-          "description": "3ch"
-        }
+      "50": {
+        "value": "0.5rem",
+        "type": "spacing"
       },
-      "column": {
-        "4xs": {
-          "value": "1px",
-          "type": "spacing"
-        },
-        "3xs": {
-          "value": "2px",
-          "type": "spacing"
-        },
-        "2xs": {
-          "value": "4px",
-          "type": "spacing"
-        },
-        "xs": {
-          "value": "8px",
-          "type": "spacing"
-        },
-        "sm": {
-          "value": "12px",
-          "type": "spacing"
-        },
-        "md": {
-          "value": "16px",
-          "type": "spacing"
-        },
-        "lg": {
-          "value": "20px",
-          "type": "spacing"
-        },
-        "xl": {
-          "value": "24px",
-          "type": "spacing"
-        },
-        "2xl": {
-          "value": "28px",
-          "type": "spacing"
-        },
-        "3xl": {
-          "value": "32px",
-          "type": "spacing"
-        },
-        "4xl": {
-          "value": "48px",
-          "type": "spacing"
-        },
-        "5xl": {
-          "value": "64px",
-          "type": "spacing"
-        },
-        "6xl": {
-          "value": "96px",
-          "type": "spacing"
-        },
-        "7xl": {
-          "value": "160px",
-          "type": "spacing"
-        }
+      "75": {
+        "value": "0.75rem",
+        "type": "spacing"
       },
-      "row": {
-        "4xs": {
-          "value": "1px",
-          "type": "spacing"
-        },
-        "3xs": {
-          "value": "2px",
-          "type": "spacing"
-        },
-        "2xs": {
-          "value": "4px",
-          "type": "spacing"
-        },
-        "sx": {
-          "value": "8px",
-          "type": "spacing"
-        },
-        "sm": {
-          "value": "12px",
-          "type": "spacing"
-        },
-        "md": {
-          "value": "16px",
-          "type": "spacing"
-        },
-        "lg": {
-          "value": "20px",
-          "type": "spacing"
-        },
-        "xl": {
-          "value": "24px",
-          "type": "spacing"
-        },
-        "2xl": {
-          "value": "28px",
-          "type": "spacing"
-        },
-        "3xl": {
-          "value": "32px",
-          "type": "spacing"
-        },
-        "4xl": {
-          "value": "48px",
-          "type": "spacing"
-        },
-        "5xl": {
-          "value": "64px",
-          "type": "spacing"
-        },
-        "6xl": {
-          "value": "96px",
-          "type": "spacing"
-        },
-        "7xl": {
-          "value": "160px",
-          "type": "spacing"
-        }
+      "100": {
+        "value": "1rem",
+        "type": "spacing"
+      },
+      "125": {
+        "value": "1.25rem",
+        "type": "spacing"
+      },
+      "150": {
+        "value": "1.5rem",
+        "type": "spacing"
+      },
+      "200": {
+        "value": "2rem",
+        "type": "spacing"
+      },
+      "250": {
+        "value": "2.5rem",
+        "type": "spacing"
+      },
+      "300": {
+        "value": "3rem",
+        "type": "spacing"
+      },
+      "400": {
+        "value": "4rem",
+        "type": "spacing"
+      },
+      "500": {
+        "value": "5rem",
+        "type": "spacing"
+      },
+      "600": {
+        "value": "6rem",
+        "type": "spacing"
       }
     },
     "border-width": {
       "sm": {
         "value": "1px",
+        "type": "borderWidth"
+      },
+      "none": {
+        "value": "0px",
         "type": "borderWidth"
       },
       "md": {
@@ -690,75 +431,45 @@
       }
     },
     "size": {
-      "5xs": {
-        "value": "2px",
+      "25": {
+        "value": "0.25rem",
         "type": "sizing"
       },
-      "4xs": {
-        "value": "4px",
+      "50": {
+        "value": "0.5rem",
         "type": "sizing"
       },
-      "3xs": {
-        "value": "8px",
+      "100": {
+        "value": "1rem",
         "type": "sizing"
       },
-      "2xs": {
-        "value": "16px",
+      "150": {
+        "value": "1.5rem",
         "type": "sizing"
       },
-      "xs": {
-        "value": "24px",
+      "200": {
+        "value": "2rem",
         "type": "sizing"
       },
-      "sm": {
-        "value": "32px",
+      "300": {
+        "value": "3rem",
         "type": "sizing"
       },
-      "md": {
-        "value": "48px",
+      "400": {
+        "value": "4rem",
         "type": "sizing"
       },
-      "lg": {
-        "value": "64px",
+      "600": {
+        "value": "6rem",
         "type": "sizing"
       },
-      "xl": {
-        "value": "96px",
+      "750": {
+        "value": "7.5rem",
         "type": "sizing"
       },
-      "2xl": {
-        "value": "160px",
+      "1000": {
+        "value": "10rem",
         "type": "sizing"
-      },
-      "icon": {
-        "sm": {
-          "value": "20px",
-          "type": "sizing"
-        },
-        "md": {
-          "value": "24px",
-          "type": "sizing"
-        },
-        "lg": {
-          "value": "24px",
-          "type": "sizing"
-        },
-        "xl": {
-          "value": "24px",
-          "type": "sizing"
-        },
-        "2xl": {
-          "value": "32px",
-          "type": "sizing"
-        },
-        "3xl": {
-          "value": "40px",
-          "type": "sizing"
-        },
-        "4xl": {
-          "value": "48px",
-          "type": "sizing"
-        }
       }
     },
     "box-shadow": {
@@ -768,7 +479,7 @@
           "y": "2",
           "blur": "6",
           "spread": "0",
-          "color": "{nijmegen.color.dark.alpha.100}",
+          "color": "{nijmegen.color.grijs.200}",
           "type": "dropShadow"
         },
         "type": "boxShadow"
@@ -779,7 +490,7 @@
           "y": "8",
           "blur": "16",
           "spread": "0",
-          "color": "{nijmegen.color.dark.alpha.100}",
+          "color": "{nijmegen.color.grijs.200}",
           "type": "dropShadow"
         },
         "type": "boxShadow"
@@ -790,7 +501,7 @@
           "y": "16",
           "blur": "48",
           "spread": "0",
-          "color": "{nijmegen.color.dark.alpha.100}",
+          "color": "{nijmegen.color.grijs.200}",
           "type": "dropShadow"
         },
         "type": "boxShadow"
@@ -805,6 +516,44 @@
           "type": "dropShadow"
         },
         "type": "boxShadow"
+      }
+    },
+    "border-radius": {
+      "none": {
+        "value": "0px",
+        "type": "borderRadius"
+      },
+      "xs": {
+        "value": "4px",
+        "type": "borderRadius"
+      },
+      "sm": {
+        "value": "8px",
+        "type": "borderRadius"
+      },
+      "md": {
+        "value": "12px",
+        "type": "borderRadius"
+      },
+      "lg": {
+        "value": "16px",
+        "type": "borderRadius"
+      },
+      "xl": {
+        "value": "32px",
+        "type": "borderRadius"
+      },
+      "2xl": {
+        "value": "40px",
+        "type": "borderRadius"
+      },
+      "3xl": {
+        "value": "64px",
+        "type": "borderRadius"
+      },
+      "circle": {
+        "value": "999px",
+        "type": "borderRadius"
       }
     }
   }

--- a/proprietary/design-tokens/src/sync/common.tokens.json
+++ b/proprietary/design-tokens/src/sync/common.tokens.json
@@ -2,56 +2,20 @@
   "nijmegen": {
     "root": {
       "background-color": {
-        "value": "{nijmegen.color.grijs.100}",
+        "value": "{nijmegen.color.background.subdued}",
         "type": "color"
       }
     },
     "document": {
-      "background-color": {
-        "value": "{nijmegen.color.white}",
-        "type": "color"
-      },
-      "color": {
-        "value": "{nijmegen.color.grijs.900}",
-        "type": "color"
-      },
       "inverse": {
         "background-color": {
           "value": "{nijmegen.color.grijs.900}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         }
-      },
-      "subtle": {
-        "color": {
-          "value": "{nijmegen.color.grijs.600}",
-          "type": "color"
-        }
-      },
-      "font-family": {
-        "value": "{nijmegen.typography.font-family.secondary}",
-        "type": "fontFamilies"
-      },
-      "font-size": {
-        "value": "{nijmegen.typography.font-size.md}",
-        "type": "fontSizes"
-      },
-      "font-weight": {
-        "value": "{nijmegen.typography.font-weight.normal}",
-        "type": "fontWeights"
-      },
-      "strong": {
-        "font-weight": {
-          "value": "{nijmegen.typography.font-weight.bold}",
-          "type": "fontWeights"
-        }
-      },
-      "line-height": {
-        "value": "{nijmegen.typography.line-height.md}",
-        "type": "lineHeights"
       }
     },
     "heading": {
@@ -64,66 +28,132 @@
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.typography.font-weight.bold}",
+        "value": "{nijmegen.typography.font-weight.semibold}",
         "type": "fontWeights"
       }
     },
-    "container": {
-      "border-color": {
-        "value": "{nijmegen.color.grijs.200}",
-        "type": "color"
+    "color": {
+      "border": {
+        "default": {
+          "value": "{nijmegen.color.grijs.500}",
+          "type": "color"
+        },
+        "subdued": {
+          "value": "{nijmegen.color.grijs.400}",
+          "type": "color"
+        },
+        "strong": {
+          "value": "{nijmegen.color.grijs.800}",
+          "type": "color"
+        }
       },
-      "border-width": {
-        "value": "{nijmegen.border-width.sm}",
-        "type": "borderWidth"
-      }
-    },
-    "line": {
-      "border-color": {
-        "value": "{nijmegen.color.grijs.200}",
-        "type": "color"
+      "feedback": {
+        "info": {
+          "default": {
+            "value": "{nijmegen.color.blauw.600}",
+            "type": "color"
+          },
+          "subdued": {
+            "value": "{nijmegen.color.blauw.200}",
+            "type": "color"
+          }
+        },
+        "error": {
+          "default": {
+            "value": "{nijmegen.color.rood.600}",
+            "type": "color"
+          },
+          "subdued": {
+            "value": "{nijmegen.color.rood.200}",
+            "type": "color"
+          }
+        },
+        "warning": {
+          "default": {
+            "value": "{nijmegen.color.oranje.600}",
+            "type": "color"
+          },
+          "subdued": {
+            "value": "{nijmegen.color.oranje.200}",
+            "type": "color"
+          }
+        },
+        "success": {
+          "subdued": {
+            "value": "{nijmegen.color.groen.600}",
+            "type": "color"
+          },
+          "default": {
+            "value": "{nijmegen.color.groen.200}",
+            "type": "color"
+          }
+        }
       },
-      "border-width": {
-        "value": "{nijmegen.border-width.sm}",
-        "type": "borderWidth"
+      "primary": {
+        "rood": {
+          "value": "{nijmegen.color.rood.700}",
+          "type": "color"
+        },
+        "zeegroen": {
+          "value": "{nijmegen.color.zeegroen.600}",
+          "type": "color"
+        }
+      },
+      "background": {
+        "default": {
+          "value": "{nijmegen.color.grijs.200}",
+          "type": "color"
+        },
+        "subdued": {
+          "value": "{nijmegen.color.grijs.100}",
+          "type": "color"
+        },
+        "hover": {
+          "value": "{nijmegen.color.grijs.300}",
+          "type": "color"
+        }
+      },
+      "foreground": {
+        "default": {
+          "value": "{nijmegen.color.grijs.900}",
+          "type": "color"
+        },
+        "subdued": {
+          "value": "{nijmegen.color.grijs.600}",
+          "type": "color"
+        },
+        "onEmphasis": {
+          "value": "{nijmegen.color.wit}",
+          "type": "color"
+        }
       }
     },
     "interaction": {
       "color": {
-        "value": "{nijmegen.color.groen.500}",
+        "value": "{nijmegen.color.primary.zeegroen}",
         "type": "color"
       },
       "active": {
         "color": {
-          "value": "{nijmegen.color.groen.600}",
+          "value": "{nijmegen.color.zeegroen.800}",
           "type": "color"
         }
       },
       "hover": {
         "color": {
-          "value": "{nijmegen.color.groen.700}",
+          "value": "{nijmegen.color.zeegroen.700}",
           "type": "color"
         }
       }
     },
     "focus": {
       "background-color": {
-        "value": "{nijmegen.color.groen.50}",
+        "value": "{nijmegen.color.zeegroen.200}",
         "type": "color"
       },
       "color": {
         "value": "{nijmegen.color.zwart}",
         "type": "color"
-      },
-      "outline-color": {
-        "value": "{nijmegen.color.groen.900}",
-        "type": "color"
-      },
-      "inverse": {
-        "outline-color": {
-          "value": "{nijmegen.color.white}",
-          "type": "color"
-        }
       },
       "outline-offset": {
         "value": "1px",
@@ -132,18 +162,6 @@
       "outline-style": {
         "value": "dashed",
         "type": "other"
-      },
-      "outline-width": {
-        "value": "{nijmegen.border-width.md}",
-        "type": "borderWidth"
-      },
-      "border-style": {
-        "value": {
-          "style": "dashed",
-          "width": "medium",
-          "color": "{nijmegen.color.lichtgroen.800}"
-        },
-        "type": "border"
       }
     },
     "form-control": {
@@ -152,15 +170,15 @@
         "type": "color"
       },
       "background-color": {
-        "value": "{nijmegen.color.white}",
+        "value": "{nijmegen.color.wit}",
         "type": "color"
       },
       "border-color": {
-        "value": "{nijmegen.color.grijs.500}",
+        "value": "{nijmegen.color.border.default}",
         "type": "color"
       },
       "color": {
-        "value": "{nijmegen.color.grijs.900}",
+        "value": "{nijmegen.color.foreground.default}",
         "type": "color"
       },
       "active": {
@@ -169,15 +187,15 @@
           "type": "color"
         },
         "background-color": {
-          "value": "{nijmegen.color.grijs.100}",
+          "value": "{nijmegen.color.background.subdued}",
           "type": "color"
         },
         "border-color": {
-          "value": "{nijmegen.color.grijs.500}",
+          "value": "{nijmegen.color.border.default}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.grijs.900}",
+          "value": "{nijmegen.color.foreground.default}",
           "type": "color"
         },
         "border-width": {
@@ -195,7 +213,7 @@
           "type": "color"
         },
         "border-color": {
-          "value": "{nijmegen.color.grijs.500}",
+          "value": "{nijmegen.color.border.default}",
           "type": "color"
         },
         "color": {
@@ -205,7 +223,7 @@
       },
       "focus": {
         "background-color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-color": {
@@ -227,15 +245,15 @@
           "type": "color"
         },
         "background-color": {
-          "value": "{nijmegen.color.grijs.100}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-color": {
-          "value": "{nijmegen.color.grijs.500}",
+          "value": "{nijmegen.color.border.default}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.grijs.900}",
+          "value": "{nijmegen.color.foreground.default}",
           "type": "color"
         },
         "border-width": {
@@ -245,15 +263,15 @@
       },
       "invalid": {
         "background-color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-color": {
-          "value": "{nijmegen.color.grijs.100}",
+          "value": "{nijmegen.color.feedback.error.default}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.rood.400}",
+          "value": "{nijmegen.color.feedback.error.default}",
           "type": "color"
         },
         "border-width": {
@@ -267,101 +285,43 @@
           "type": "color"
         },
         "border-color": {
-          "value": "transparent",
+          "value": "{nijmegen.color.none}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.grijs.900}",
+          "value": "{nijmegen.color.foreground.default}",
           "type": "color"
         }
       },
       "placeholder": {
         "color": {
-          "value": "{nijmegen.color.grijs.500}",
+          "value": "{nijmegen.color.foreground.subdued}",
           "type": "color"
         }
       },
       "border-width": {
         "value": "{nijmegen.border-width.sm}",
         "type": "borderWidth"
-      }
-    },
-    "feedback": {
-      "info-default": {
-        "color": {
-          "value": "{nijmegen.color.donkerblauw.100}",
-          "type": "color"
-        }
       },
-      "error-default": {
-        "background-color": {
-          "value": "{nijmegen.color.rood.100}",
-          "type": "color"
-        }
-      },
-      "warning-default": {
-        "color": {
-          "value": "{nijmegen.color.oranje.500}",
-          "type": "color"
-        }
-      },
-      "info-subdued": {
-        "color": {
-          "value": "{nijmegen.color.blauw.100}",
-          "type": "color"
-        }
-      },
-      "warning-subsued": {
-        "background-color": {
-          "value": "{nijmegen.color.oranje.100}",
-          "type": "color"
-        }
-      },
-      "success-subsued": {
-        "background-color": {
-          "value": "{nijmegen.color.groen.100}",
-          "type": "color"
-        }
-      },
-      "error-subsued": {
-        "background-color": {
-          "value": "{nijmegen.color.rood.100}",
-          "type": "color"
-        }
-      },
-      "success-default": {
-        "background-color": {
-          "value": "{nijmegen.color.lichtgroen.500}",
-          "type": "color"
-        }
-      },
-      "success-sudsued": {
-        "background-color": {
-          "value": "{nijmegen.color.lichtgroen.100}",
-          "type": "color"
-        }
-      }
-    },
-    "pointer-target": {
-      "min-size": {
-        "value": "{nijmegen.size.md}",
+      "max-inline-size": {
+        "value": "400px",
         "type": "sizing"
+      },
+      "border-radius": {
+        "value": "{nijmegen.border-radius.xs}",
+        "type": "borderRadius"
       }
     },
     "icon": {
       "functional": {
         "size": {
-          "value": "{nijmegen.size.xs}",
-          "type": "sizing"
-        },
-        "size1": {
-          "value": "{nijmegen.size.2xs}",
+          "value": "{nijmegen.size.150}",
           "type": "sizing"
         }
       },
       "toptask": {
         "size": {
-          "value": "{nijmegen.size.md}",
+          "value": "{nijmegen.size.300}",
           "type": "sizing"
         }
       }
@@ -371,35 +331,55 @@
         "value": "underline",
         "type": "textDecoration"
       }
+    }
+  },
+  "utrecht": {
+    "document": {
+      "background-color": {
+        "value": "{nijmegen.color.wit}",
+        "type": "color"
+      },
+      "color": {
+        "value": "{nijmegen.color.foreground.default}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.typography.font-family.secondary}",
+        "type": "fontFamilies"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.md}",
+        "type": "fontSizes"
+      },
+      "font-weight": {
+        "value": "{nijmegen.typography.font-weight.regular}",
+        "type": "fontWeights"
+      },
+      "line-height": {
+        "value": "{nijmegen.typography.line-height.md}",
+        "type": "lineHeights"
+      }
     },
-    "border-radius": {
-      "xs": {
-        "value": "4px",
-        "type": "borderRadius"
+    "focus": {
+      "outline-color": {
+        "value": "{nijmegen.color.zeegroen.900}",
+        "type": "color"
       },
-      "sm": {
-        "value": "12px",
-        "type": "borderRadius"
+      "inverse": {
+        "outline-color": {
+          "value": "{nijmegen.color.wit}",
+          "type": "color"
+        }
       },
-      "md": {
-        "value": "16px",
-        "type": "borderRadius"
-      },
-      "lg": {
-        "value": "32px",
-        "type": "borderRadius"
-      },
-      "xl": {
-        "value": "40px",
-        "type": "borderRadius"
-      },
-      "2xl": {
-        "value": "64px",
-        "type": "borderRadius"
-      },
-      "round": {
-        "value": "999px",
-        "type": "borderRadius"
+      "outline-width": {
+        "value": "{nijmegen.border-width.md}",
+        "type": "borderWidth"
+      }
+    },
+    "pointer-target": {
+      "min-size": {
+        "value": "{nijmegen.size.400}",
+        "type": "sizing"
       }
     }
   },

--- a/proprietary/design-tokens/src/sync/components/accordion.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/accordion.tokens.json
@@ -15,7 +15,7 @@
           "value": "auto"
         },
         "border-color": {
-          "value": "{nijmegen.line.border-color}",
+          "value": "{nijmegen.color.border.subdued}",
           "type": "color"
         }
       },
@@ -51,7 +51,7 @@
           "type": "fontSizes"
         },
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         },
         "icon": {
@@ -114,7 +114,7 @@
         },
         "background-color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         },
         "border-color": {
           "value": "transparent",
@@ -157,11 +157,11 @@
           "value": "{nijmegen.border-width.sm}"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.semi-bold}",
+          "value": "{nijmegen.typography.font-weight.semibold}",
           "type": "fontWeights"
         }
       }

--- a/proprietary/design-tokens/src/sync/components/alert.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/alert.tokens.json
@@ -15,7 +15,7 @@
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{nijmegen.typography.font-size.xl}",
+          "value": "{1.5rem}",
           "type": "fontSizes"
         }
       },
@@ -53,7 +53,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },
@@ -105,7 +105,7 @@
       },
       "negative": {
         "background-color": {
-          "value": "{nijmegen.feedback.error-default.background-color}",
+          "value": "{nijmegen.color.feedback.error.default}",
           "type": "color"
         },
         "border-color": {
@@ -113,7 +113,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },
@@ -127,7 +127,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },
@@ -141,7 +141,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },

--- a/proprietary/design-tokens/src/sync/components/avatar.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/avatar.tokens.json
@@ -2,7 +2,7 @@
   "nl": {
     "avatar": {
       "size": {
-        "value": "{nijmegen.pointer-target.min-size}",
+        "value": "{utrecht.pointer-target.min-size}",
         "type": "sizing"
       },
       "icon": {
@@ -20,12 +20,12 @@
         "type": "color"
       },
       "color": {
-        "value": "{nijmegen.color.white}",
+        "value": "{nijmegen.color.wit}",
         "type": "color"
       },
       "text": {
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "font-weight": {
@@ -33,7 +33,7 @@
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         },
         "text-transform": {
@@ -41,7 +41,7 @@
           "type": "textCase"
         },
         "font-size": {
-          "value": "{nijmegen.document.font-size}",
+          "value": "{utrecht.document.font-size}",
           "type": "fontSizes"
         }
       },
@@ -59,7 +59,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         }
       }

--- a/proprietary/design-tokens/src/sync/components/badge.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/badge.tokens.json
@@ -2,7 +2,7 @@
   "nijmegen": {
     "badge": {
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
@@ -10,11 +10,11 @@
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "positive": {
@@ -23,7 +23,7 @@
           "type": "color"
         },
         "background-color": {
-          "value": "{nijmegen.feedback.success-default.background-color}",
+          "value": "{nijmegen.color.feedback.success.default}",
           "type": "color"
         },
         "border-color": {
@@ -71,7 +71,7 @@
       },
       "warning": {
         "color": {
-          "value": "{nijmegen.feedback.warning-default.color}",
+          "value": "{nijmegen.color.feedback.warning.default}",
           "type": "color"
         },
         "background-color": {
@@ -85,7 +85,7 @@
       },
       "informative": {
         "color": {
-          "value": "{nijmegen.feedback.info-default.color}",
+          "value": "{nijmegen.color.feedback.info.default}",
           "type": "color"
         },
         "background-color": {

--- a/proprietary/design-tokens/src/sync/components/blockquote.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/blockquote.tokens.json
@@ -7,7 +7,7 @@
           "type": "fontSizes"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "line-height": {
@@ -15,7 +15,7 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "padding-block-start": {
@@ -37,15 +37,15 @@
           "type": "lineHeights"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{nijmegen.typography.font-size.xl}",
+          "value": "{1.5rem}",
           "type": "fontSizes"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },

--- a/proprietary/design-tokens/src/sync/components/breadcrumb.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/breadcrumb.tokens.json
@@ -2,11 +2,11 @@
   "utrecht": {
     "breadcrumb": {
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "link": {
@@ -88,7 +88,7 @@
       "divider": {
         "size": {
           "type": "sizing",
-          "value": "{nijmegen.size.2xs}"
+          "value": "{nijmegen.size.150}"
         },
         "color": {
           "value": "{nijmegen.color.grijs.400}",
@@ -100,11 +100,11 @@
         "type": "spacing"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/button.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/button.tokens.json
@@ -13,7 +13,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.color.white}"
+            "value": "{nijmegen.color.wit}"
           }
         },
         "background-color": {
@@ -26,7 +26,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         },
         "disabled": {
           "background-color": {
@@ -71,7 +71,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.color.white}"
+            "value": "{nijmegen.color.wit}"
           }
         }
       },
@@ -92,7 +92,7 @@
         },
         "background-color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         },
         "border-color": {
           "type": "color",
@@ -172,11 +172,11 @@
         }
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
@@ -258,7 +258,7 @@
         }
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "padding-block-end": {
@@ -316,7 +316,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         }
       },
       "active": {
@@ -330,7 +330,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         }
       },
       "background-color": {
@@ -343,15 +343,15 @@
       },
       "color": {
         "type": "color",
-        "value": "{nijmegen.color.white}"
+        "value": "{nijmegen.color.wit}"
       },
       "min-block-size": {
         "type": "sizing",
-        "value": "{nijmegen.pointer-target.min-size}"
+        "value": "{utrecht.pointer-target.min-size}"
       },
       "min-inline-size": {
         "type": "sizing",
-        "value": "{nijmegen.pointer-target.min-size}"
+        "value": "{utrecht.pointer-target.min-size}"
       },
       "text-decoration": {
         "value": "{nijmegen.hover.text-decoration}",
@@ -369,7 +369,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.color.white}"
+            "value": "{nijmegen.color.wit}"
           }
         },
         "background-color": {
@@ -382,7 +382,7 @@
         },
         "color": {
           "type": "color",
-          "value": "{nijmegen.color.white}"
+          "value": "{nijmegen.color.wit}"
         },
         "disabled": {
           "background-color": {
@@ -423,7 +423,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.color.white}"
+            "value": "{nijmegen.color.wit}"
           }
         }
       }

--- a/proprietary/design-tokens/src/sync/components/card-event.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/card-event.tokens.json
@@ -39,7 +39,7 @@
           }
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.semi-bold}",
+          "value": "{nijmegen.typography.font-weight.semibold}",
           "type": "fontWeights"
         },
         "line-height": {
@@ -61,7 +61,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.normal}",
+          "value": "{nijmegen.typography.font-weight.regular}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -75,7 +75,7 @@
           "type": "color"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.normal}",
+          "value": "{nijmegen.typography.font-weight.regular}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -93,7 +93,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.normal}",
+          "value": "{nijmegen.typography.font-weight.regular}",
           "type": "fontWeights"
         },
         "font-size": {

--- a/proprietary/design-tokens/src/sync/components/card-persona.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/card-persona.tokens.json
@@ -6,7 +6,7 @@
         "type": "color"
       },
       "border-color": {
-        "value": "{nijmegen.container.border-color}",
+        "value": "{nijmegen.color.border.default}",
         "type": "color"
       },
       "border-radius": {
@@ -45,7 +45,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.semi-bold}",
+          "value": "{nijmegen.typography.font-weight.semibold}",
           "type": "fontWeights"
         },
         "font-size": {
@@ -77,7 +77,7 @@
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.typography.font-weight.normal}",
+          "value": "{nijmegen.typography.font-weight.regular}",
           "type": "fontWeights"
         },
         "font-size": {

--- a/proprietary/design-tokens/src/sync/components/card-searchresults.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/card-searchresults.tokens.json
@@ -3,7 +3,7 @@
     "card-searchresults": {
       "base": {
         "background-color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-width": {
@@ -30,11 +30,11 @@
             "type": "fontFamilies"
           },
           "font-size": {
-            "value": "{nijmegen.typography.font-size.xl}",
+            "value": "{1.5rem}",
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{nijmegen.typography.font-weight.semi-bold}",
+            "value": "{nijmegen.typography.font-weight.semibold}",
             "type": "fontWeights"
           },
           "line-height": {
@@ -56,7 +56,7 @@
             "type": "fontSizes"
           },
           "font-weight": {
-            "value": "{nijmegen.typography.font-weight.normal}",
+            "value": "{nijmegen.typography.font-weight.regular}",
             "type": "fontWeights"
           },
           "line-height": {

--- a/proprietary/design-tokens/src/sync/components/card-topics.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/card-topics.tokens.json
@@ -3,7 +3,7 @@
     "card-topics": {
       "base": {
         "background-color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-color": {
@@ -61,7 +61,7 @@
       },
       "title": {
         "font-size": {
-          "value": "{nijmegen.typography.font-size.xl}",
+          "value": "{1.5rem}",
           "type": "fontSizes"
         }
       },

--- a/proprietary/design-tokens/src/sync/components/cards-news.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/cards-news.tokens.json
@@ -2,11 +2,11 @@
   "nijmegen": {
     "card-nieuws": {
       "background-color": {
-        "value": "{nijmegen.color.white}",
+        "value": "{nijmegen.color.wit}",
         "type": "color"
       },
       "border-color": {
-        "value": "{nijmegen.container.border-color}",
+        "value": "{nijmegen.color.border.default}",
         "type": "color"
       },
       "border-radius": {

--- a/proprietary/design-tokens/src/sync/components/checkbox.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/checkbox.tokens.json
@@ -7,7 +7,7 @@
       },
       "size": {
         "type": "sizing",
-        "value": "{nijmegen.size.xs}"
+        "value": "{nijmegen.size.200}"
       },
       "icon": {
         "size": {
@@ -71,7 +71,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-width": {
@@ -88,7 +88,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           }
         },
@@ -124,7 +124,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           }
         },
@@ -142,7 +142,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           }
         }
@@ -157,7 +157,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "border-width": {
@@ -174,7 +174,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           }
         },
@@ -188,7 +188,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           },
           "border-width": {
@@ -206,7 +206,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           },
           "border-width": {

--- a/proprietary/design-tokens/src/sync/components/data-list.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/data-list.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "data-list": {
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "item-value": {
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "row": {
@@ -91,20 +91,20 @@
           "value": "{nijmegen.border-width.sm}"
         },
         "border-color": {
-          "value": "{nijmegen.line.border-color}",
+          "value": "{nijmegen.color.border.subdued}",
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         }
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "item-action": {

--- a/proprietary/design-tokens/src/sync/components/email-input.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/email-input.tokens.json
@@ -6,19 +6,19 @@
         "value": "0px"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "max-inline-size": {

--- a/proprietary/design-tokens/src/sync/components/focus-ring.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/focus-ring.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "focus": {
       "outline-width": {
-        "value": "{nijmegen.focus.outline-width}",
+        "value": "{utrecht.focus.outline-width}",
         "type": "borderWidth"
       },
       "outline-offset": {
@@ -10,11 +10,11 @@
         "type": "focus"
       },
       "inverse-outline-color": {
-        "value": "{nijmegen.focus.inverse.outline-color}",
+        "value": "{utrecht.focus.inverse.outline-color}",
         "type": "color"
       },
       "outline-color": {
-        "value": "{nijmegen.focus.outline-color}",
+        "value": "{utrecht.focus.outline-color}",
         "type": "color"
       },
       "outline-style": {

--- a/proprietary/design-tokens/src/sync/components/form-field-description.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/form-field-description.tokens.json
@@ -6,19 +6,19 @@
         "value": "{nijmegen.document.subtle.color}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/form-field-error-message.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/form-field-error-message.tokens.json
@@ -16,19 +16,19 @@
         "value": "{nijmegen.color.donkerrood.100}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/form-field-label.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/form-field-label.tokens.json
@@ -3,14 +3,14 @@
     "form-field-label": {
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
@@ -18,7 +18,7 @@
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/form-field-option-label.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/form-field-option-label.tokens.json
@@ -6,19 +6,19 @@
         "type": "color"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "disabled": {

--- a/proprietary/design-tokens/src/sync/components/heading.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading.tokens.json
@@ -62,7 +62,7 @@
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.typography.font-size.xl}",
+        "value": "{1.5rem}",
         "type": "fontSizes"
       }
     },

--- a/proprietary/design-tokens/src/sync/components/link-list.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/link-list.tokens.json
@@ -108,7 +108,7 @@
         }
       },
       "font-weight": {
-        "value": "{nijmegen.typography.font-weight.normal}",
+        "value": "{nijmegen.typography.font-weight.regular}",
         "type": "fontWeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/link.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/link.tokens.json
@@ -2,7 +2,7 @@
   "utrecht": {
     "link": {
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "color": {
@@ -76,11 +76,11 @@
         }
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "text-decoration-thickness": {
@@ -92,7 +92,7 @@
         "type": "other"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/ordered-list.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/ordered-list.tokens.json
@@ -7,22 +7,22 @@
       },
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "font-familiy": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "item": {

--- a/proprietary/design-tokens/src/sync/components/pagination.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/pagination.tokens.json
@@ -103,16 +103,16 @@
           "type": "borderRadius"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "min-block-size": {
           "type": "sizing",
-          "value": "{nijmegen.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
           "type": "sizing",
-          "value": "{nijmegen.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}"
         },
         "previous": {
           "padding-inline-end": {
@@ -133,7 +133,7 @@
           "value": "{nijmegen.border-width.sm}"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "current": {
@@ -155,7 +155,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.document.color}"
+            "value": "{utrecht.document.color}"
           }
         },
         "border-radius": {
@@ -246,11 +246,11 @@
         },
         "min-block-size": {
           "type": "sizing",
-          "value": "{nijmegen.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}"
         },
         "min-inline-size": {
           "type": "sizing",
-          "value": "{nijmegen.pointer-target.min-size}"
+          "value": "{utrecht.pointer-target.min-size}"
         }
       },
       "gap": {
@@ -258,15 +258,15 @@
         "type": "spacing"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "ellipses": {
@@ -291,7 +291,7 @@
           "type": "color"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         }
       }

--- a/proprietary/design-tokens/src/sync/components/paragraph.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/paragraph.tokens.json
@@ -3,32 +3,32 @@
     "paragraph": {
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     },
     "paragraph-lead": {
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
@@ -36,21 +36,21 @@
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     },
     "paragraph-small-print": {
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
@@ -58,11 +58,11 @@
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/radio.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/radio.tokens.json
@@ -17,12 +17,12 @@
       },
       "size": {
         "type": "sizing",
-        "value": "{nijmegen.size.xs}"
+        "value": "{nijmegen.size.200}"
       },
       "dot": {
         "size": {
           "type": "sizing",
-          "value": "{nijmegen.size.3xs}"
+          "value": "{nijmegen.size.100}"
         }
       },
       "background-color": {
@@ -81,7 +81,7 @@
           "type": "color"
         },
         "color": {
-          "value": "{nijmegen.color.white}",
+          "value": "{nijmegen.color.wit}",
           "type": "color"
         },
         "hover": {
@@ -94,7 +94,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           },
           "border-width": {
@@ -112,7 +112,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           },
           "border-width": {
@@ -148,7 +148,7 @@
             "type": "color"
           },
           "color": {
-            "value": "{nijmegen.color.white}",
+            "value": "{nijmegen.color.wit}",
             "type": "color"
           }
         },

--- a/proprietary/design-tokens/src/sync/components/select.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/select.tokens.json
@@ -116,19 +116,19 @@
         "type": "borderWidth"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "max-inline-size": {

--- a/proprietary/design-tokens/src/sync/components/separator.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/separator.tokens.json
@@ -2,11 +2,11 @@
   "utrecht": {
     "separator": {
       "color": {
-        "value": "{nijmegen.line.border-color}",
+        "value": "{nijmegen.color.border.subdued}",
         "type": "color"
       },
       "block-size": {
-        "value": "{nijmegen.size.4xs}",
+        "value": "{nijmegen.size.50}",
         "type": "sizing"
       },
       "padding-block-end": {

--- a/proprietary/design-tokens/src/sync/components/sidenav.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/sidenav.tokens.json
@@ -3,7 +3,7 @@
     "sidenav": {
       "link": {
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         },
         "icon": {
@@ -17,15 +17,15 @@
           }
         },
         "font-size": {
-          "value": "{nijmegen.document.font-size}",
+          "value": "{utrecht.document.font-size}",
           "type": "fontSizes"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "current": {
@@ -35,7 +35,7 @@
           },
           "color": {
             "type": "color",
-            "value": "{nijmegen.document.color}"
+            "value": "{utrecht.document.color}"
           }
         },
         "color": {

--- a/proprietary/design-tokens/src/sync/components/skip-link.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/skip-link.tokens.json
@@ -6,24 +6,24 @@
         "type": "fontWeights"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "min-block-size": {
         "type": "sizing",
-        "value": "{nijmegen.pointer-target.min-size}"
+        "value": "{utrecht.pointer-target.min-size}"
       },
       "min-inline-size": {
         "type": "sizing",
-        "value": "{nijmegen.pointer-target.min-size}"
+        "value": "{utrecht.pointer-target.min-size}"
       },
       "padding-block-end": {
         "value": "{nijmegen.space.block.sm}",

--- a/proprietary/design-tokens/src/sync/components/table.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/table.tokens.json
@@ -3,15 +3,15 @@
     "table": {
       "header-cell": {
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "font-weight": {
@@ -19,7 +19,7 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{nijmegen.document.font-size}",
+          "value": "{utrecht.document.font-size}",
           "type": "fontSizes"
         }
       },
@@ -45,7 +45,7 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{nijmegen.typography.font-size.xl}",
+          "value": "{1.5rem}",
           "type": "fontSizes"
         }
       },
@@ -69,23 +69,23 @@
       },
       "data-cell": {
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "font-weight": {
-          "value": "{nijmegen.document.font-weight}",
+          "value": "{utrecht.document.font-weight}",
           "type": "fontWeights"
         },
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         },
         "font-size": {
-          "value": "{nijmegen.document.font-size}",
+          "value": "{utrecht.document.font-size}",
           "type": "fontSizes"
         }
       },
@@ -95,7 +95,7 @@
           "type": "borderWidth"
         },
         "border-block-end-color": {
-          "value": "{nijmegen.line.border-color}",
+          "value": "{nijmegen.color.border.subdued}",
           "type": "color"
         },
         "background-color": {
@@ -109,7 +109,7 @@
           "type": "borderWidth"
         },
         "border-block-end-color": {
-          "value": "{nijmegen.line.border-color}",
+          "value": "{nijmegen.color.border.subdued}",
           "type": "color"
         },
         "background-color": {
@@ -123,7 +123,7 @@
           "type": "borderWidth"
         },
         "border-block-end-color": {
-          "value": "{nijmegen.line.border-color}",
+          "value": "{nijmegen.color.border.subdued}",
           "type": "color"
         },
         "background-color": {
@@ -137,19 +137,19 @@
           "type": "fontWeights"
         },
         "font-size": {
-          "value": "{nijmegen.document.font-size}",
+          "value": "{utrecht.document.font-size}",
           "type": "fontSizes"
         },
         "color": {
-          "value": "{nijmegen.document.color}",
+          "value": "{utrecht.document.color}",
           "type": "color"
         },
         "font-family": {
-          "value": "{nijmegen.document.font-family}",
+          "value": "{utrecht.document.font-family}",
           "type": "fontFamilies"
         },
         "line-height": {
-          "value": "{nijmegen.document.line-height}",
+          "value": "{utrecht.document.line-height}",
           "type": "lineHeights"
         }
       },

--- a/proprietary/design-tokens/src/sync/components/textarea.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/textarea.tokens.json
@@ -134,19 +134,19 @@
         "type": "borderWidth"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       }
     }

--- a/proprietary/design-tokens/src/sync/components/textbox.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/textbox.tokens.json
@@ -6,19 +6,19 @@
         "value": "0px"
       },
       "font-family": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "max-inline-size": {

--- a/proprietary/design-tokens/src/sync/components/unordered-list.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/unordered-list.tokens.json
@@ -3,32 +3,32 @@
     "unordered-list": {
       "color": {
         "type": "color",
-        "value": "{nijmegen.document.color}"
+        "value": "{utrecht.document.color}"
       },
       "marker": {
         "border-color": {
           "type": "color",
-          "value": "{nijmegen.document.color}"
+          "value": "{utrecht.document.color}"
         },
         "color": {
           "type": "color",
-          "value": "{nijmegen.document.color}"
+          "value": "{utrecht.document.color}"
         }
       },
       "font-familiy": {
-        "value": "{nijmegen.document.font-family}",
+        "value": "{utrecht.document.font-family}",
         "type": "fontFamilies"
       },
       "font-size": {
-        "value": "{nijmegen.document.font-size}",
+        "value": "{utrecht.document.font-size}",
         "type": "fontSizes"
       },
       "font-weight": {
-        "value": "{nijmegen.document.font-weight}",
+        "value": "{utrecht.document.font-weight}",
         "type": "fontWeights"
       },
       "line-height": {
-        "value": "{nijmegen.document.line-height}",
+        "value": "{utrecht.document.line-height}",
         "type": "lineHeights"
       },
       "padding-inline-start": {


### PR DESCRIPTION
- Removed token `nijmegen.focus.border-style` because `outline-style` already exists.
- Removed `border-radius` tokens because these are already brand tokens.
- Removed `nijmegen.focus.border-style` and `nijmegen.line-border-width` because container and line brand tokens were deleted.
- Renamed prefix of `nijmegen.focus-outline-width` to `utrecht`.
- Added token `nijmegen.form-control.border-radius`.
 