### PR TITLE
feat: add link tokens

### DIFF
--- a/proprietary/design-tokens/src/sync/components/link.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/link.tokens.json
@@ -1,10 +1,6 @@
 {
   "utrecht": {
     "link": {
-      "line-height": {
-        "$type": "lineHeights",
-        "$value": "{utrecht.document.line-height}"
-      },
       "color": {
         "$type": "color",
         "$value": "{nijmegen.interaction.color}"
@@ -17,10 +13,6 @@
         "color": {
           "$type": "color",
           "$value": "{nijmegen.interaction.active.color}"
-        },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "none"
         }
       },
       "focus": {
@@ -31,10 +23,12 @@
         "color": {
           "$type": "color",
           "$value": "{nijmegen.focus.color}"
-        },
+        }
+      },
+      "focus-visible": {
         "text-decoration": {
           "$type": "textDecoration",
-          "$value": "none"
+          "$value": "None"
         },
         "text-decoration-thickness": {
           "$type": "other",
@@ -48,7 +42,7 @@
         },
         "text-decoration": {
           "$type": "textDecoration",
-          "$value": "none"
+          "$value": "None"
         },
         "text-decoration-thickness": {
           "$type": "other",
@@ -71,14 +65,6 @@
           "$value": "{nijmegen.icon.functional.size}"
         }
       },
-      "font-size": {
-        "$type": "fontSizes",
-        "$value": "{utrecht.document.font-size}"
-      },
-      "font-family": {
-        "$type": "fontFamilies",
-        "$value": "{utrecht.document.font-family}"
-      },
       "text-decoration-thickness": {
         "$type": "other",
         "$value": "auto"
@@ -87,9 +73,9 @@
         "$type": "other",
         "$value": "auto"
       },
-      "font-weight": {
-        "$type": "fontWeights",
-        "$value": "{utrecht.document.font-weight}"
+      "column-gap": {
+        "$type": "spacing",
+        "$value": "{nijmegen.space.25}"
       }
     }
   }


### PR DESCRIPTION
Aligned link tokens with `utrecht` code.

Renamed tokens:

- `link.icon.margin-inline` to `link.column-gap`
- `link.focus.text-decoration` to `link.focus-visible.text-decoration`
- `link.focus.text-decoration-thickness` to `link.focus-visible.text-decoration-thickness`

Deleted (referenced to .document) tokens:

- font-family
- font-size
- font-weight
- line-height

Deleted tokens:

- active.text-decoration