### PR TITLE
feat: add link-list tokens

### DIFF
--- a/proprietary/design-tokens/src/sync/brand.tokens.json
+++ b/proprietary/design-tokens/src/sync/brand.tokens.json
@@ -359,6 +359,10 @@
         "$type": "spacing",
         "$value": "0rem"
       },
+      "12": {
+        "$type": "spacing",
+        "$value": "0.125rem"
+      },
       "25": {
         "$type": "spacing",
         "$value": "0.25rem"

--- a/proprietary/design-tokens/src/sync/components/link-list.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/link-list.tokens.json
@@ -1,97 +1,51 @@
 {
-  "nijmegen": {
+  "utrecht": {
     "link-list": {
-      "base": {
-        "background-color": {
-          "$type": "color",
-          "$value": "transparent"
-        },
-        "text-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.500}"
-        },
-        "font-family": {
-          "$type": "fontFamilies",
-          "$value": "{nijmegen.typography.font-family.secondary}"
-        },
-        "font-size": {
-          "$type": "fontSizes",
-          "$value": "{nijmegen.typography.font-size.md}"
-        },
-        "line-height": {
-          "$type": "lineHeights",
-          "$value": "{nijmegen.typography.line-height.md}"
-        },
-        "border-radius": {
-          "$type": "borderRadius",
-          "$value": "{nijmegen.border-radius.xs}"
-        }
+      "row-gap": {
+        "$type": "spacing",
+        "$value": "{nijmegen.space.50}"
       },
-      "hover": {
-        "text-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.700}"
+      "icon": {
+        "inset-block-start": {
+          "$type": "spacing",
+          "$value": "{nijmegen.space.12}"
+        },
+        "size": {
+          "$type": "sizing",
+          "$value": "{nijmegen.icon.functional.size}"
+        }
+      }
+    }
+  },
+  "todo": {
+    "link-list": {
+      "item": {
+        "column-gap": {
+          "$type": "spacing",
+          "$value": "{nijmegen.space.50}"
         },
         "text-decoration": {
           "$type": "textDecoration",
-          "$value": "{nijmegen.hover.text-decoration}"
+          "$value": "None"
+        },
+        "active": {
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "underline"
+          }
+        },
+        "focus": {
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "None"
+          }
+        },
+        "hover": {
+          "text-decoration": {
+            "$type": "textDecoration",
+            "$value": "underline"
+          }
         }
-      },
-      "focus": {
-        "text-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.900}"
-        },
-        "border-style": {
-          "$type": "border",
-          "$value": "solid"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{nijmegen.border-width.md}"
-        }
-      },
-      "focus-visible": {
-        "text-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.900}"
-        },
-        "border-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.900}"
-        },
-        "border-style": {
-          "$type": "border",
-          "$value": "dotted"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "{nijmegen.border-width.md}"
-        }
-      },
-      "visited": {
-        "text-color": {
-          "$type": "color",
-          "$value": "{nijmegen.color.groen.700}"
-        },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "{nijmegen.hover.text-decoration}"
-        }
-      },
-      "active": {
-        "border-style": {
-          "$type": "border",
-          "$value": "{nijmegen.link-list.focus.border-style}"
-        },
-        "border-width": {
-          "$type": "borderWidth",
-          "$value": "2px"
-        }
-      },
-      "font-weight": {
-        "$type": "fontWeights",
-        "$value": "{nijmegen.typography.font-weight.regular}"
       }
     }
   }

--- a/proprietary/design-tokens/src/sync/components/link.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/link.tokens.json
@@ -1,10 +1,6 @@
 {
   "utrecht": {
     "link": {
-      "line-height": {
-        "$type": "lineHeights",
-        "$value": "{utrecht.document.line-height}"
-      },
       "color": {
         "$type": "color",
         "$value": "{nijmegen.interaction.color}"
@@ -17,10 +13,6 @@
         "color": {
           "$type": "color",
           "$value": "{nijmegen.interaction.active.color}"
-        },
-        "text-decoration": {
-          "$type": "textDecoration",
-          "$value": "none"
         }
       },
       "focus": {
@@ -31,10 +23,12 @@
         "color": {
           "$type": "color",
           "$value": "{nijmegen.focus.color}"
-        },
+        }
+      },
+      "focus-visible": {
         "text-decoration": {
           "$type": "textDecoration",
-          "$value": "none"
+          "$value": "None"
         },
         "text-decoration-thickness": {
           "$type": "other",
@@ -48,7 +42,7 @@
         },
         "text-decoration": {
           "$type": "textDecoration",
-          "$value": "none"
+          "$value": "None"
         },
         "text-decoration-thickness": {
           "$type": "other",
@@ -71,14 +65,6 @@
           "$value": "{nijmegen.icon.functional.size}"
         }
       },
-      "font-size": {
-        "$type": "fontSizes",
-        "$value": "{utrecht.document.font-size}"
-      },
-      "font-family": {
-        "$type": "fontFamilies",
-        "$value": "{utrecht.document.font-family}"
-      },
       "text-decoration-thickness": {
         "$type": "other",
         "$value": "auto"
@@ -87,9 +73,9 @@
         "$type": "other",
         "$value": "auto"
       },
-      "font-weight": {
-        "$type": "fontWeights",
-        "$value": "{utrecht.document.font-weight}"
+      "column-gap": {
+        "$type": "spacing",
+        "$value": "{nijmegen.space.25}"
       }
     }
   }


### PR DESCRIPTION
Replaced the old Link List component with the new `utrecht` Link List component, including some todo tokens.

Also added `nijmegen.space.12` with a value of `0.125rem` (2px). 

