### PR TITLE
fix: revert conversion to W3C DTCG format

### DIFF
--- a/proprietary/design-tokens/src/sync/$metadata.json
+++ b/proprietary/design-tokens/src/sync/$metadata.json
@@ -26,7 +26,13 @@
     "components/form-field-label.tokens",
     "components/form-field-option-label.tokens",
     "components/form-field-radio-option.tokens",
-    "components/heading.tokens",
+    "components/header.tokens",
+    "components/heading-1.tokens",
+    "components/heading-2.tokens",
+    "components/heading-3.tokens",
+    "components/heading-4.tokens",
+    "components/heading-5.tokens",
+    "components/heading-6.tokens",
     "components/icon-only-button.tokens",
     "components/link.tokens",
     "components/link-list.tokens",
@@ -43,7 +49,7 @@
     "components/textarea.tokens",
     "components/textbox.tokens",
     "components/toolbar-button.tokens",
-    "components/header.tokens",
-    "components/unordered-list.tokens"
+    "components/unordered-list.tokens",
+    "components/heading.tokens"
   ]
 }

--- a/proprietary/design-tokens/src/sync/components/header.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/header.tokens.json
@@ -1,1 +1,130 @@
-{}
+{
+  "nijmegen": {
+    "header": {
+      "item": {
+        "color": {
+          "value": "{utrecht.document.color}",
+          "type": "color"
+        },
+        "hover": {
+          "color": {
+            "value": "{nijmegen.interaction.hover.color}",
+            "type": "color"
+          },
+          "text-decoration": {
+            "value": "underline",
+            "type": "textDecoration"
+          }
+        },
+        "active": {
+          "color": {
+            "value": "{nijmegen.interaction.active.color}",
+            "type": "color"
+          },
+          "text-decoration": {
+            "value": "underline",
+            "type": "textDecoration"
+          }
+        },
+        "font-weight": {
+          "value": "{utrecht.document.font-weight}",
+          "type": "fontWeights"
+        },
+        "font-family": {
+          "value": "{utrecht.document.font-family}",
+          "type": "fontFamilies"
+        },
+        "font-size": {
+          "value": "{utrecht.document.font-size}",
+          "type": "fontSizes"
+        },
+        "line-height": {
+          "value": "{utrecht.document.line-height}",
+          "type": "lineHeights"
+        },
+        "current": {
+          "font-weight": {
+            "value": "{nijmegen.typography.font-weight.bold}",
+            "type": "fontWeights"
+          }
+        },
+        "icon": {
+          "size": {
+            "value": "{nijmegen.icon.functional.size}",
+            "type": "sizing"
+          }
+        },
+        "focus-visible": {
+          "color": {
+            "value": "{nijmegen.focus.color}",
+            "type": "color"
+          },
+          "background-color": {
+            "value": "{nijmegen.focus.background-color}",
+            "type": "color"
+          }
+        },
+        "column-gap": {
+          "value": "{nijmegen.space.25}",
+          "type": "spacing"
+        }
+      },
+      "padding-inline-start": {
+        "value": "{nijmegen.space.50}",
+        "type": "spacing"
+      },
+      "padding-block-start": {
+        "value": "{nijmegen.space.50}",
+        "type": "spacing"
+      },
+      "padding-block-end": {
+        "value": "{nijmegen.space.50}",
+        "type": "spacing"
+      },
+      "padding-inline-end": {
+        "value": "{nijmegen.space.50}",
+        "type": "spacing"
+      },
+      "border-color": {
+        "value": "{nijmegen.color.border.subdued}",
+        "type": "color"
+      },
+      "border-block-end-width": {
+        "value": "{nijmegen.border-width.sm}",
+        "type": "borderWidth"
+      },
+      "max-inline-size": {
+        "value": "1280px",
+        "type": "sizing"
+      },
+      "background-color": {
+        "value": "{utrecht.document.background-color}",
+        "type": "color"
+      },
+      "large-vw": {
+        "padding-inline-start": {
+          "value": "{nijmegen.space.0}",
+          "type": "spacing"
+        },
+        "padding-block-start": {
+          "value": "{nijmegen.space.100}",
+          "type": "spacing"
+        },
+        "padding-block-end": {
+          "value": "{nijmegen.space.100}",
+          "type": "spacing"
+        },
+        "padding-inline-end": {
+          "value": "{nijmegen.space.0}",
+          "type": "spacing"
+        }
+      },
+      "content": {
+        "column-gap": {
+          "value": "{nijmegen.space.150}",
+          "type": "spacing"
+        }
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-1.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-1.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-1": {
+      "color": {
+        "value": "{nijmegen.color.primary.rood}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.typography.font-family.primary}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.typography.font-weight.bold}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.4xl}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{nijmegen.typography.line-height.sm}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-2.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-2.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-2": {
+      "color": {
+        "value": "{nijmegen.heading.color}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.heading.font-family}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.heading.font-weight}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.3xl}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{nijmegen.typography.line-height.sm}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-3.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-3.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-3": {
+      "color": {
+        "value": "{nijmegen.heading.color}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.heading.font-family}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.heading.font-weight}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.2xl}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{nijmegen.typography.line-height.sm}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-4.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-4.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-4": {
+      "color": {
+        "value": "{nijmegen.heading.color}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.heading.font-family}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.heading.font-weight}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.xl}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{utrecht.document.line-height}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-5.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-5.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-5": {
+      "color": {
+        "value": "{nijmegen.heading.color}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.heading.font-family}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.heading.font-weight}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.lg}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{utrecht.document.line-height}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/heading-6.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-6.tokens.json
@@ -1,0 +1,26 @@
+{
+  "utrecht": {
+    "heading-6": {
+      "color": {
+        "value": "{nijmegen.heading.color}",
+        "type": "color"
+      },
+      "font-family": {
+        "value": "{nijmegen.heading.font-family}",
+        "type": "fontFamilies"
+      },
+      "font-weight": {
+        "value": "{nijmegen.heading.font-weight}",
+        "type": "fontWeights"
+      },
+      "font-size": {
+        "value": "{nijmegen.typography.font-size.md}",
+        "type": "fontSizes"
+      },
+      "line-height": {
+        "value": "{utrecht.document.line-height}",
+        "type": "lineHeights"
+      }
+    }
+  }
+}

--- a/proprietary/design-tokens/src/sync/components/icon-only-button.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/icon-only-button.tokens.json
@@ -1,1 +1,22 @@
-{}
+{
+  "nijmegen": {
+    "icon-only-button": {
+      "padding-block-end": {
+        "value": "{nijmegen.space.75}",
+        "type": "spacing"
+      },
+      "padding-block-start": {
+        "value": "{nijmegen.space.75}",
+        "type": "spacing"
+      },
+      "padding-inline-end": {
+        "value": "{nijmegen.space.75}",
+        "type": "spacing"
+      },
+      "padding-inline-start": {
+        "value": "{nijmegen.space.75}",
+        "type": "spacing"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The W3C DTCG format was unexpectedly enabled automatically. This PR restores the original state by disabling it.