### PR TITLE
style: remove text-decoration from button

### DIFF
--- a/proprietary/design-tokens/src/sync/$metadata.json
+++ b/proprietary/design-tokens/src/sync/$metadata.json
@@ -53,7 +53,6 @@
     "components/textarea.tokens",
     "components/textbox.tokens",
     "components/toolbar-button.tokens",
-    "components/header.tokens",
     "components/unordered-list.tokens",
     "layout.tokens"
   ]

--- a/proprietary/design-tokens/src/sync/components/accordion.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/accordion.tokens.json
@@ -26,7 +26,7 @@
         },
         "expanded": {
           "background-color": {
-            "value": "{nijmegen.color.grijs.100}",
+            "value": "{nijmegen.color.background.default}",
             "type": "color"
           },
           "border-color": {
@@ -61,11 +61,11 @@
           "type": "borderWidth"
         },
         "padding-block-end": {
-          "value": "{nijmegen.space.150}",
+          "value": "{nijmegen.space.100}",
           "type": "spacing"
         },
         "padding-block-start": {
-          "value": "{nijmegen.space.150}",
+          "value": "{nijmegen.space.100}",
           "type": "spacing"
         },
         "padding-inline-end": {
@@ -146,7 +146,7 @@
         },
         "active": {
           "background-color": {
-            "value": "{nijmegen.color.grijs.300}",
+            "value": "{nijmegen.color.background.active}",
             "type": "color"
           },
           "border-color": {

--- a/proprietary/design-tokens/src/sync/components/button.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/button.tokens.json
@@ -354,15 +354,5 @@
         "type": "sizing"
       }
     }
-  },
-  "todo": {
-    "button": {
-      "hover": {
-        "text-decoration": {
-          "value": "{nijmegen.hover.text-decoration}",
-          "type": "textDecoration"
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
In overleg met Vladimir bepaald dat de volgende token niet meer nodig is:

`todo.button.hover.text-decoration`

Door deze token niet toe te voegen, kunnen we gebruikmaken van de Community 'Utrecht' Button.

Deze is bovendien niet doorgekomen in de [implementatie van de Button](https://wowebnl.github.io/design-system-nijmegen/?path=/docs/css-button--docs). 