### PR TITLE
feat: typography foundation

### DIFF
--- a/packages/storybook/src/foundations/Typography/DeveloperDocs.mdx
+++ b/packages/storybook/src/foundations/Typography/DeveloperDocs.mdx
@@ -1,0 +1,31 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="foundations/typography/Developer documentation"/>
+# Fonts
+---
+
+<div style={{display: "grid", gridTemplateColumns: "1fr 1fr"}}>
+    <div>
+        ### Headings
+        <div className="nijmegen-theme utrecht-html">
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-3xl)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)" }}>Oranda BT</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>abcdefghijklmnopqrstuvwxyz (&*%$!?”)</span>\
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>1234567890 (&*%$!?”)</span>
+        </div>
+    </div>
+    <div>
+        ### Subheadings and content 
+        <div className="nijmegen-theme">
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-3xl)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)" }}>Source Sans Pro</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>abcdefghijklmnopqrstuvwxyz (&*%$!?”)</span>\
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>1234567890 (&*%$!?”)</span>
+        </div>
+    </div>
+</div>
+All fonts are loaded via the `@gemeentenijmegen/font` package.

--- a/packages/storybook/src/foundations/Typography/Documentatie.mdx
+++ b/packages/storybook/src/foundations/Typography/Documentatie.mdx
@@ -1,0 +1,32 @@
+# Typografie
+
+Op de websites van de Gemeente Nijmegen worden de lettertypes Oranda BT en Source Sans Pro gebruikt. Dit helpt bij het georganiseerd presenteren van informatie en vergemakkelijkt het navigeren voor gebruikers. Door het consistent gebruik van kopniveaus begrijpen gebruikers beter hoe de pagina is opgebouwd.
+
+Het Oranda BT-lettertype is ook een essentieel onderdeel van de herkenbaarheid van de Gemeente Nijmegen. Het is belangrijk om bij voorkeur geen andere lettertypen te gebruiken om een consistente uitstraling te behouden.
+      
+---
+
+<div style={{display: "grid", gridTemplateColumns: "1fr 1fr"}}>
+    <div>
+        ### Sitenamen en koppen
+        <div className="nijmegen-theme utrecht-html">
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-3xl)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)" }}>Oranda BT</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>abcdefghijklmnopqrstuvwxyz (&*%$!?”)</span>\
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-primary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>1234567890 (&*%$!?”)</span>
+        </div>
+    </div>
+    <div>
+        ### Subkoppen en content 
+        <div className="nijmegen-theme">
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-3xl)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)" }}>Source Sans Pro</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>abcdefghijklmnopqrstuvwxyz (&*%$!?”)</span>\
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>ABCDEFGHIJKLMNOPQRSTUVWXYZ</span>
+
+        <span style={{fontFamily: "var(--nijmegen-typography-font-family-secondary)", fontSize: "var( --nijmegen-typography-font-size-md)", color: "var(--nijmegen-color-grijs-800)", fontWeight: "var(--nijmegen-typography-font-weight-bold)"  }}>1234567890 (&*%$!?”)</span>
+        </div>
+    </div>
+</div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,16 @@ importers:
       '@fontsource/source-sans-pro':
         specifier: 5.0.8
         version: 5.0.8
+    devDependencies:
+      postcss-discard-duplicates:
+        specifier: 7.0.1
+        version: 7.0.1(postcss@8.4.35)
+      rollup:
+        specifier: 4.12.1
+        version: 4.12.1
+      rollup-plugin-postcss:
+        specifier: 4.0.2
+        version: 4.0.2(postcss@8.4.35)
 
 packages:
 
@@ -4533,7 +4543,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 4.12.1
@@ -6640,10 +6650,6 @@ packages:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
     dev: true
 
-  /@types/estree@1.0.1:
-    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
-    dev: true
-
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
@@ -8342,8 +8348,8 @@ packages:
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
-      browserslist: 4.21.9
-      caniuse-lite: 1.0.30001565
+      browserslist: 4.22.2
+      caniuse-lite: 1.0.30001583
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
@@ -12278,7 +12284,7 @@ packages:
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.5
     dev: true
 
   /is-regex@1.1.4:
@@ -12800,7 +12806,7 @@ packages:
       jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
-      resolve: 1.22.2
+      resolve: 1.22.8
       resolve.exports: 2.0.2
       slash: 3.0.0
     dev: true
@@ -14950,7 +14956,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.8
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: true
@@ -14960,7 +14966,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.12.1
+      is-core-module: 2.13.1
       semver: 7.6.3
       validate-npm-package-license: 3.0.4
     dev: true
@@ -15970,7 +15976,7 @@ packages:
       postcss: ^8.2.2
     dependencies:
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -15980,7 +15986,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.22.2
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.35
@@ -15993,7 +15999,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.22.2
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
     dev: true
@@ -16081,11 +16087,11 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.22.2
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.4.35)
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
     dev: true
 
   /postcss-minify-font-values@5.1.0(postcss@8.4.35):
@@ -16116,7 +16122,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.22.2
       cssnano-utils: 3.1.0(postcss@8.4.35)
       postcss: 8.4.35
       postcss-value-parser: 4.2.0
@@ -16129,7 +16135,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
     dev: true
 
   /postcss-modules-extract-imports@3.0.0(postcss@8.4.35):
@@ -16160,7 +16166,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
     dev: true
 
   /postcss-modules-values@4.0.0(postcss@8.4.35):
@@ -16376,7 +16382,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
     dev: true
 
   /postcss-value-parser@4.2.0:
@@ -18405,9 +18411,9 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.22.2
       postcss: 8.4.35
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
     dev: true
 
   /stylelint-config-recommended-scss@14.0.0(postcss@8.4.35)(stylelint@16.2.1):
@@ -18481,7 +18487,7 @@ packages:
       known-css-properties: 0.29.0
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.1
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.15
       postcss-value-parser: 4.2.0
       stylelint: 16.2.1(typescript@5.3.3)
     dev: true

--- a/proprietary/font/LICENSE.md
+++ b/proprietary/font/LICENSE.md
@@ -1,7 +1,5 @@
 # License
 
-Copyright (c) {year} {author}. All rights reserved.
-
-The open source license does NOT apply to files in this directory.
-
-These are properietary assets to {author}.
+Code: EUPL v1.2
+Source Sans Pro font: [SIL Open Font License, Version 1.1](https://openfontlicense.org/open-font-license-official-text/)
+Oranda BT font: Copyright Bitstream, @todo add license

--- a/proprietary/font/README.md
+++ b/proprietary/font/README.md
@@ -1,3 +1,3 @@
-# Assets
+# Nijmegen fonts
 
-Story any font files here, such as proprietary fonts.
+Fonts used by the Design System of the municipality Nijmegen.

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -1,14 +1,18 @@
 {
   "version": "0.0.1",
   "author": "gemeente Nijmegen",
-  "description": "Font assets",
+  "description": "Font package for the Municipality of Nijmegen",
   "license": "SEE LICENSE IN LICENSE.md",
   "name": "@gemeentenijmegen/font",
   "main": "dist/index.css",
   "keywords": [
     "nl-design-system"
   ],
-  "private": true,
+  "scripts": {
+    "build": "rollup -c ./rollup.config.mjs",
+    "clean": "rimraf dist"
+  },
+  "private": false,
   "publishConfig": {
     "access": "public"
   },
@@ -17,9 +21,14 @@
   ],
   "repository": {
     "type": "git+ssh",
-    "url": "git@github.com:nl-design-system/example.git"
+    "url": "git@github.com:GemeenteNijmegen/design-system.git"
   },
   "dependencies": {
     "@fontsource/source-sans-pro": "5.0.8"
+  },
+  "devDependencies": {
+    "postcss-discard-duplicates": "7.0.1",
+    "rollup": "4.12.1",
+    "rollup-plugin-postcss": "4.0.2"
   }
 }

--- a/proprietary/font/rollup.config.mjs
+++ b/proprietary/font/rollup.config.mjs
@@ -1,0 +1,38 @@
+import postcss from "rollup-plugin-postcss";
+import discardDuplicates from "postcss-discard-duplicates";
+
+export default [
+  {
+    input: "src/index.scss",
+    output: {
+      file: "dist/index.css",
+      sourcemap: false,
+      format: "esm",
+      compact: true,
+    },
+    plugins: [
+      postcss({
+        extensions: [".css", ".scss"],
+        plugins: [discardDuplicates()],
+        extract: true,
+      }),
+    ],
+  },
+  {
+    input: "src/index.scss",
+    output: {
+      file: "dist/index.min.css",
+      sourcemap: false,
+      format: "esm",
+      compact: true,
+    },
+    plugins: [
+      postcss({
+        extensions: [".css", ".scss"],
+        plugins: [discardDuplicates()],
+        extract: true,
+        minimize: true,
+      }),
+    ],
+  },
+];

--- a/proprietary/font/src/index.scss
+++ b/proprietary/font/src/index.scss
@@ -1,12 +1,3 @@
-/*
-You can install your own font files, or install font packages from npm.
-FontSource <https://fontsource.org> contains many fonts that can installed via npm
-so you don't have to use a CDN or hosted files from Google Fonts.
-
-Here's "Open Sans", for example.
-https://fontsource.org/fonts/open-sans
-*/
-
 @import "@fontsource/source-sans-pro/400.css";
 @import "@fontsource/source-sans-pro/600.css";
 @import "@fontsource/source-sans-pro/700.css";


### PR DESCRIPTION
@joostvanderborg er is geen licentie voor Ordana font bijgevoegd en zoals het nu is ingesteld wordt het font package gepubliceerd op NPM, ik weet niet of de licentie die Nijmegen heeft op het font dit toelaat, anders de `private` parameter wijzigingen in proprietary/font/package.json  naar `private:true`