### PR TITLE
pnpm/action-setup update for cache error

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -165,7 +165,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -20,7 +20,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -44,7 +44,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -71,7 +71,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -119,7 +119,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -170,7 +170,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/gh-pages-deployment.yml
+++ b/.github/workflows/gh-pages-deployment.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 

--- a/.github/workflows/gh-pages-deployment.yml
+++ b/.github/workflows/gh-pages-deployment.yml
@@ -20,7 +20,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -44,7 +44,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -71,7 +71,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/test-design-tokens.yml
+++ b/.github/workflows/test-design-tokens.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4.1.1
 
       - name: Install pnpm package manager
-        uses: pnpm/action-setup@v3.0.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 8.14
 

--- a/.github/workflows/test-design-tokens.yml
+++ b/.github/workflows/test-design-tokens.yml
@@ -21,7 +21,7 @@ jobs:
           version: 8.14
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm


### PR DESCRIPTION
Actions runnen nu extreem lang omdat er een oude cache service gebruikt wordt door de dep die niet meer ondersteund wordt door GH