### PR TITLE
style: change font-weight of headings

### DIFF
--- a/proprietary/design-tokens/src/sync/common.tokens.json
+++ b/proprietary/design-tokens/src/sync/common.tokens.json
@@ -28,7 +28,7 @@
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.typography.font-weight.semibold}",
+        "value": "{nijmegen.typography.font-weight.bold}",
         "type": "fontWeights"
       }
     },

--- a/proprietary/design-tokens/src/sync/components/heading-1.tokens.json
+++ b/proprietary/design-tokens/src/sync/components/heading-1.tokens.json
@@ -10,7 +10,7 @@
         "type": "fontFamilies"
       },
       "font-weight": {
-        "value": "{nijmegen.typography.font-weight.bold}",
+        "value": "{nijmegen.heading.font-weight}",
         "type": "fontWeights"
       },
       "font-size": {


### PR DESCRIPTION
De waarde van de volgende tokens zijn gewijzigd:

- `nijmegen.heading.font-weight` naar brand token `nijmegen.typography.font-weight.bold`
- `utrecht.heading-1.font-weight` naar common token `nijmegen.typography.font-weight.bold`

De font-weight van heading-2 t/m heading-6 is met deze aanpassing dus ook veranderd.