### PR TITLE
Serveral focus related style tweaks

### DIFF
--- a/packages/components-css/breadcrumb/index.scss
+++ b/packages/components-css/breadcrumb/index.scss
@@ -14,6 +14,8 @@
   line-height: var(--nijmegen-breadcrumb-navigation-line-height);
   margin-block-end: var(--nijmegen-breadcrumb-margin-block-end);
   overflow: hidden;
+  padding-block-end: 0.25rem; // For the focus border
+  padding-block-start: 0.25rem; // For the focus border
 }
 
 .nijmegen-breadcrumb__list {

--- a/packages/components-css/footer/index.scss
+++ b/packages/components-css/footer/index.scss
@@ -17,6 +17,19 @@
       text-decoration-color: inherit;
     }
 
+    &:focus:any-link {
+      color: var(--nijmegen-link-list-item-focus-color, #000);
+      text-decoration: var(--nijmegen-link-list-item-focus-text-decoration, none);
+    }
+
+    &:focus-visible:any-link {
+      color: var(--nijmegen-link-list-item-focus-visible-color, #000);
+    }
+  }
+
+  .nijmegen-link-list__link:any-link {
+    color: inherit;
+
     &:focus {
       color: var(--nijmegen-link-list-item-focus-color, #000);
       text-decoration: var(--nijmegen-link-list-item-focus-text-decoration, none);
@@ -25,22 +38,9 @@
     &:focus-visible {
       color: var(--nijmegen-link-list-item-focus-visible-color, #000);
     }
-  }
-
-  .nijmegen-link-list__link:any-link {
-    color: inherit;
 
     &::before {
-      background-color: var(--nijmegen-page-footer-color);
-    }
-
-    &:hover,
-    &.nijmegen-link-list__link--hover {
-      color: inherit;
-
-      &::before {
-        background-color: var(--nijmegen-page-footer-color);
-      }
+      background-color: currentColor;
     }
   }
 }

--- a/packages/components-css/skip-link/index.scss
+++ b/packages/components-css/skip-link/index.scss
@@ -10,6 +10,7 @@
   display: inline-block;
   font-size: var(--utrecht-document-font-size);
   line-height: var(--utrecht-document-line-height);
+  margin: 0.5rem; /* stylelint-disable-line property-disallowed-list */
   margin-block-end: var(--nijmegen-skip-link-margin-block-end);
   min-block-size: var(--utrecht-pointer-target-min-size);
   min-inline-size: var(--utrecht-pointer-target-min-size);


### PR DESCRIPTION
Fixed the focus border on serveral components:
- Breadcrumb
- Footer
- Skiplink